### PR TITLE
#163840 - CupertinoButton cursor doesn't change to clickable on desktop

### DIFF
--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -89,6 +89,7 @@ class CupertinoButton extends StatefulWidget {
     this.focusNode,
     this.onFocusChange,
     this.autofocus = false,
+    this.mouseCursor,
     this.onLongPress,
     required this.onPressed,
   }) : assert(pressedOpacity == null || (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
@@ -124,6 +125,7 @@ class CupertinoButton extends StatefulWidget {
     this.focusNode,
     this.onFocusChange,
     this.autofocus = false,
+    this.mouseCursor,
     this.onLongPress,
     required this.onPressed,
   }) : assert(minimumSize == null || minSize == null),
@@ -153,6 +155,7 @@ class CupertinoButton extends StatefulWidget {
     this.focusNode,
     this.onFocusChange,
     this.autofocus = false,
+    this.mouseCursor,
     this.onLongPress,
     required this.onPressed,
   }) : assert(pressedOpacity == null || (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
@@ -256,6 +259,12 @@ class CupertinoButton extends StatefulWidget {
 
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
+
+  /// The cursor that will be shown when hovering over the button.
+  ///
+  /// If null, defaults to [SystemMouseCursors.click] on web and
+  /// [MouseCursor.defer] on other platforms.
+  final MouseCursor? mouseCursor;
 
   final _CupertinoButtonStyle _style;
 
@@ -431,7 +440,10 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
     );
 
     return MouseRegion(
-      cursor: enabled && kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
+      cursor:
+          enabled
+              ? widget.mouseCursor ?? (kIsWeb ? SystemMouseCursors.click : MouseCursor.defer)
+              : MouseCursor.defer,
       child: FocusableActionDetector(
         actions: _actionMap,
         focusNode: widget.focusNode,

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -885,6 +885,90 @@ void main() {
     await tester.pump();
     expect(value, isTrue);
   });
+
+  testWidgets('CupertinoButton.mouseCursor behavior', (WidgetTester tester) async {
+    const SystemMouseCursor customCursor = SystemMouseCursors.grab;
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoButton(
+            onPressed: () {},
+            mouseCursor: customCursor,
+            child: const Text('Tap Me'),
+          ),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+      pointer: 1,
+    );
+    // Get the center of the CupertinoButton to ensure the pointer is over it
+    final Offset buttonCenter = tester.getCenter(find.text('Tap Me'));
+    await gesture.addPointer(location: buttonCenter);
+    await tester.pumpAndSettle();
+
+    // Expect the custom cursor to be active when the mouse is over the button
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), customCursor);
+  });
+
+  testWidgets('CupertinoButton.Filled.mouseCursor behavior', (WidgetTester tester) async {
+    const SystemMouseCursor customCursor = SystemMouseCursors.grab;
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoButton.filled(
+            onPressed: () {},
+            mouseCursor: customCursor,
+            child: const Text('Tap Me'),
+          ),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+      pointer: 1,
+    );
+    // Get the center of the CupertinoButton to ensure the pointer is over it
+    final Offset buttonCenter = tester.getCenter(find.text('Tap Me'));
+    await gesture.addPointer(location: buttonCenter);
+    await tester.pumpAndSettle();
+
+    // Expect the custom cursor to be active when the mouse is over the button
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), customCursor);
+  });
+
+  testWidgets('CupertinoButton.Tinted.mouseCursor behavior', (WidgetTester tester) async {
+    const SystemMouseCursor customCursor = SystemMouseCursors.grab;
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: CupertinoButton.tinted(
+            onPressed: () {},
+            mouseCursor: customCursor,
+            child: const Text('Tap Me'),
+          ),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+      pointer: 1,
+    );
+    // Get the center of the CupertinoButton to ensure the pointer is over it
+    final Offset buttonCenter = tester.getCenter(find.text('Tap Me'));
+    await gesture.addPointer(location: buttonCenter);
+    await tester.pumpAndSettle();
+
+    // Expect the custom cursor to be active when the mouse is over the button
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), customCursor);
+  });
 }
 
 Widget boilerplate({required Widget child}) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR addresses Issue number: 163840, where when hovering over a Cupertino button the mouse cursor wouldn't switch to clickable and there wasn't any option to configure it.

Adds Mouse cursor to CupertinoButton, CupertinoButton.Filled and CupertinoButton.Tinted

Fixes https://github.com/flutter/flutter/issues/163840
Part of https://github.com/flutter/flutter/issues/58192

Demo of the changes

https://github.com/user-attachments/assets/2e5d874e-cdfe-44bf-9710-bbbde99be3f7

Code snippet showing new behavior

```dart
import 'package:flutter/cupertino.dart';

void main() => runApp(
  // const Center(child: Text('Hello, world!', key: Key('title'), textDirection: TextDirection.ltr)),
  CupertinoApp(
    theme: const CupertinoThemeData(
      brightness: Brightness.light,
    ),
    home: Center(
      child: Column(
        spacing: 5.0,
        mainAxisAlignment: MainAxisAlignment.center,
        crossAxisAlignment: CrossAxisAlignment.center,
        children: <Widget>[
          CupertinoButton(
            onPressed: (){},
            child: const Text('Default Cursor'),
          ),
          CupertinoButton(
            onPressed: (){},
            mouseCursor: SystemMouseCursors.grab,
            child: const Text('Custom Cursor'),
          ),
          CupertinoButton.filled(
            onPressed: (){},
            mouseCursor: SystemMouseCursors.copy,
            child: const Text('Custom Cursor 2'),
          ),
          CupertinoButton.tinted(
            onPressed: (){},
            mouseCursor: SystemMouseCursors.help,
            child: const Text('Custom Cursor 2'),
          ),
        ],
      )
    ),
  ),
);
```


*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist



- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
